### PR TITLE
Fix issue3 clean

### DIFF
--- a/src/components/MapComponent.tsx
+++ b/src/components/MapComponent.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MapContainer, TileLayer, GeoJSON, LayersControl, useMap } from "react-leaflet";
+import { MapContainer, TileLayer, GeoJSON, LayersControl, useMap, ZoomControl } from "react-leaflet";
 import L from "leaflet";
 import 'leaflet/dist/leaflet.css';
 import 'leaflet.fullscreen/Control.FullScreen.css';
@@ -33,7 +33,7 @@ const FullscreenControl: React.FC = () => {
   const map = useMap();
   // Add fullscreen control only once
   if (!controlAdded) {
-    const fullscreenControl = L.control.fullscreen({ position: "topright" });
+    const fullscreenControl = L.control.fullscreen({ position: "topleft" });
     fullscreenControl.addTo(map);
     controlAdded = true; // Mark as added
   }
@@ -114,12 +114,16 @@ const MapComponent: React.FC<MapComponentProps> = ({ geoJsonData }) => {
       center={[20, 30]} // Default center of the map
       zoom={2} // Default zoom level
       style={mapContainerStyle}
+      zoomControl={false} // Disable default zoom control, we'll add it manually
     >
+      {/* Add Zoom Control (Top Left) */}
+      <ZoomControl position="topleft" />
+      
       {/* Add Fullscreen Control */}
       <FullscreenControl />
 
       {/* Base Layers */}
-      <LayersControl position="topright">
+      <LayersControl position="topleft">
         <LayersControl.BaseLayer name="GoogleStreets">
           <TileLayer
             url="http://{s}.google.com/vt/lyrs=m&x={x}&y={y}&z={z}"

--- a/src/components/MapComponent.tsx
+++ b/src/components/MapComponent.tsx
@@ -4,6 +4,7 @@ import L from "leaflet";
 import 'leaflet/dist/leaflet.css';
 import 'leaflet.fullscreen/Control.FullScreen.css';
 import 'leaflet.fullscreen';
+import './scss/MapComponent.scss';
 
 
 interface GeoJSONFeature {
@@ -72,10 +73,39 @@ const MapComponent: React.FC<MapComponentProps> = ({ geoJsonData }) => {
 
   const onEachFeature = (feature: any, layer: L.Layer) => {
     if (feature.properties) {
-      const timeLapseLink = feature.timelapse_link ? `<br><br><a href="${feature.timelapse_link}" target="_blank">Timelapse Link</a>` : ""
-      layer.bindPopup(
-        `<b>${feature.properties.uniqueId}</b><br>${feature.properties.kfwProjectNoINPRO}<br><br>${feature.properties.locationName}<br><br>${feature.properties.activityDescriptionGeneral}<br>Type: ${feature.properties.sector_location.location_type}${timeLapseLink}`
-      );
+      const props = feature.properties;
+      const timeLapseLink = feature.timelapse_link ? 
+        `<a href="${feature.timelapse_link}" target="_blank">Timelapse Link</a>` : "";
+      
+      // Create a formatted HTML string with all the requested fields in the exact order from the table
+      const popupContent = `
+        <div class="map-popup">
+          <h3>${props.locationName || 'N/A'}</h3>
+          <div class="popup-content">
+            <p><span class="popup-label">Unique ID:</span> <span class="popup-value">${props.uniqueId || 'N/A'}</span></p>
+            <p><span class="popup-label">Inpro Nr.:</span> <span class="popup-value">${props.kfwProjectNoINPRO || 'N/A'}</span></p>
+            <p><span class="popup-label">Project Acronym:</span> <span class="popup-value">${props.projectAcronym || 'N/A'}</span></p>
+            <p><span class="popup-label">Data Owner:</span> <span class="popup-value">${props.dataOwner || 'N/A'}</span></p>
+            <p><span class="popup-label">Publishing Restrictions:</span> <span class="popup-value">${props.publishingRestrictions || 'N/A'}</span></p>
+            <p><span class="popup-label">Date of Data Collection:</span> <span class="popup-value">${props.dateOfDataCollection || 'N/A'}</span></p>
+            <p><span class="popup-label">Location Identifier:</span> <span class="popup-value">${props.projectSpecificLocationIdentifier || 'N/A'}</span></p>
+            <p><span class="popup-label">Location name:</span> <span class="popup-value">${props.locationName || 'N/A'}</span></p>
+            <p><span class="popup-label">Activity Status:</span> <span class="popup-value">${props.locationActivityStatus || 'N/A'}</span></p>
+            <p><span class="popup-label">Start Date:</span> <span class="popup-value">${props.plannedOrActualStartDate || 'N/A'}</span></p>
+            <p><span class="popup-label">End Date:</span> <span class="popup-value">${props.plannedOrActualEndDate || 'N/A'}</span></p>
+            <p><span class="popup-label">Activity Description:</span> <span class="popup-value">${props.activityDescriptionGeneral || 'N/A'}</span></p>
+            <p><span class="popup-label">Activity Details:</span> <span class="popup-value">${props.additionalActivityDescription || 'N/A'}</span></p>
+            <p><span class="popup-label">Location Type:</span> <span class="popup-value">${props.sector_location?.location_type || 'N/A'}</span></p>
+            <p><span class="popup-label">DAC5 Sector:</span> <span class="popup-value">${props.dac5PurposeCode || 'N/A'}</span></p>
+            <p><span class="popup-label">Geographic Exactness:</span> <span class="popup-value">${props.geographicExactness || 'N/A'}</span></p>
+            <p><span class="popup-label">Related Community or Village:</span> <span class="popup-value">${props.relatedCommunityVillageNeighborhood || 'N/A'}</span></p>
+            <p><span class="popup-label">Scheme Version:</span> <span class="popup-value">${props.schemeVersion || 'N/A'}</span></p>
+            ${timeLapseLink ? `<div>${timeLapseLink}</div>` : ''}
+          </div>
+        </div>
+      `;
+      
+      layer.bindPopup(popupContent);
     }
   };
 
@@ -143,8 +173,8 @@ const mapContainerStyle: React.CSSProperties = {
   position: "relative",
   display: "flex",
   alignItems: "left",
-  width: "100%", // Full width or set a specific width, e.g., "70%"
-  maxWidth: "1280px", // Optional: limit the max width of the map
-  aspectRatio: "16 / 9", // Maintain the 16:9 ratio
+  width: "100%", // Full width to match text description
+  maxWidth: "100%", // Remove previous constraint of 1280px to use full width
+  aspectRatio: "16 / 13.5", // Adjusted from 16/9 to make it 50% taller
   margin: "20px 0",
 };

--- a/src/components/scss/FileValidator.scss
+++ b/src/components/scss/FileValidator.scss
@@ -1,5 +1,3 @@
-
-
 .file_validator {
 
 	header p {
@@ -37,8 +35,8 @@
 		position: relative;
 		display: flex;
 		align-items: left;
-		width: 70%;
-		height: 400px;
+		width: 100%;
+		height: 600px;
 		margin: 20px 0;
 	}
 

--- a/src/components/scss/MapComponent.scss
+++ b/src/components/scss/MapComponent.scss
@@ -1,0 +1,57 @@
+// Map popup styles
+.map-popup {
+  max-width: 700px;
+  font-family: Arial, sans-serif;
+
+  h3 {
+    margin: 0 0 10px 0;
+    padding-bottom: 5px;
+    border-bottom: 1px solid #eee;
+    font-size: 16px;
+    font-weight: bold;
+  }
+
+  .popup-content {
+    margin-top: 5px;
+  }
+
+  p {
+    margin: 5px 0;
+    font-size: 13px;
+    line-height: 1.4;
+  }
+
+  .popup-label {
+    font-weight: 600;
+    display: inline-block;
+    min-width: 170px;
+  }
+
+  .popup-value {
+    display: inline-block;
+  }
+
+  a {
+    display: inline-block;
+    margin-top: 10px;
+    padding: 5px 10px;
+    background: #4a90e2;
+    color: #fff;
+    text-decoration: none;
+    border-radius: 3px;
+    font-size: 13px;
+    
+    &:hover {
+      background: #3a80d2;
+    }
+  }
+}
+
+// Improve leaflet popup styling
+.leaflet-popup-content {
+  margin: 12px 15px;
+}
+
+.leaflet-container a.leaflet-popup-close-button {
+  padding: 6px;
+} 


### PR DESCRIPTION
Enhanced the map popups to display all required fields as specified in the issue #3 :

- Used locationName as the header/title
- Added all 18 fields marked with "yes" in the table
- Used proper labels as specified in the "name for OGM Validator Popup" column
- Added fallbacks for missing data with 'N/A'

Improved the popup styling:
- Increased the popup width to 700px for better readability
- Added clean, consistent formatting with labels and values
- Improved typography and visual organization

Enlarged the map:
- Set the width to 100% to use the full available width
- Increased the height by 50% (from 400px to 600px)
- Adjusted the aspect ratio for better proportions
 
Fixed the control positioning:
- Moved all map controls (zoom, fullscreen button, and layer switcher) to the top-left corner
- Prevented overlap with other UI elements